### PR TITLE
Test conda-build 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,8 @@ install:
       conda config --set show_channel_urls true
       conda install --yes --quiet conda-forge-build-setup
       source run_conda_forge_build_setup
+      # Test conda-build 2.
+      conda install conda-build=2 --yes
 
 script:
   - conda build ./recipe

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -41,6 +41,9 @@ conda clean --lock
 conda install --yes --quiet conda-forge-build-setup
 source run_conda_forge_build_setup
 
+# Test conda-build 2.
+conda install conda-build=2 --yes
+
 # Embarking on 1 case(s).
     set -x
     export CONDA_PERL=5.20.3.1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,8 +22,9 @@ requirements:
 test:
   commands:
     - makeinfo -h
-    #- conda inspect linkages -p $PREFIX texinfo  # [not win]
-    #- conda inspect objects -p $PREFIX texinfo  # [osx]
+    - conda inspect linkages -p $PREFIX texinfo  # [not win]
+    - conda inspect objects -p $PREFIX texinfo  # [osx]
+    - conda inspect prefix-lengths /feedstock_root/build_artefacts/linux-64/*.tar.bz2  # [linux]
 
 about:
   home: http://www.gnu.org/software/texinfo/


### PR DESCRIPTION
Ping @nsoranzo and @bgruening.

Locally I got:

```shell
+ conda inspect prefix-lengths /opt/conda/conda-bld/linux-64/texinfo-6.1-pl5.20.3_3.tar.bz2
No packages found with binary prefixes shorter than 255 characters.
```

Is that OK for you guys?